### PR TITLE
Theoretically remove extra characters which break input

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -63,6 +63,15 @@ async function onMessageHandler(channel, user, msg, self) {
     }
     let input = msg.split(" ");
 
+    for (let i = 0; i < input.length; i++) {
+        if (new RegExp(/[\uDB40-\uDC00]/).test(input[i])) {
+            input[i] = input[i].replace(new RegExp(/[\uDB40-\uDC00]/g), "");
+            input[i] = input[i].replace(/\s\s+/g, ' ').trim();
+            input.splice(i)
+        }
+    }
+    input = input.filter(e => e);
+
     const Alias = new tools.Alias(msg);
     input = msg.replace(Alias.getRegex(), Alias.getReplacement()).split(' ');
     let realcommand = input[1];


### PR DESCRIPTION
Removes a few UTF-16 characters from the end of the input as chatterino adds then and results in the bot not capable of reading the input. 
For example if you send two words in chatterio it adds a second space in between the two, 
[bb 'space' 'space' ping]

If there are more than two characters it adds two special UTF-16 characters at the end of the input.
[bb ping 'space' '\uDB40' '\uDC00']