### PR TITLE
Fix: Cookie & Cdr Reminder

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -215,7 +215,7 @@ async function onMessageHandler(channel, user, msg, self) {
             new messageHandler(res.Channel, res.msg).newMessage();
 			return;
         }
-        else if (positive_bot.cdr.validateIsPositiveBot(input, user)) {
+        else if (positive_bot.cdr.validateIsPositiveBot(user, input)) {
             const status = await positive_bot.cdr.setCdr(input, channel);
             const message = (dst, prefix = '', suffix = '') => new messageHandler(dst, `${prefix} I will remind you to use your cdr in 3 hours nymnOkay ${suffix}`).newMessage();
         

--- a/bot.js
+++ b/bot.js
@@ -223,7 +223,7 @@ async function onMessageHandler(channel, user, msg, self) {
             let [checkmode] = await sql.Query('SELECT Mode FROM Cookies WHERE User=?', [status.User]);
             if (!checkmode) return;
         
-            if (await tools.commandDisabled(channel, 'cdr')) {
+            if (await tools.commandDisabled('cdr', channel)) {
                 if (status.Status === 'Confirmed' && checkmode.Mode === mode.whereAte) {
                     message(channel, status.User, '- (The channel you used your cdr in has reminders disabled)');
                     return;

--- a/loops/loops.js
+++ b/loops/loops.js
@@ -210,15 +210,17 @@ setInterval(async function () {
 
             /** @type { SQL.Streamers[] } */
             const [stream] = await sql.Query('SELECT islive, username FROM Streamers WHERE username=?', [user.Channel]);
-			if (stream === null) return;
             await sql.Query('UPDATE Cookies SET Status=?, Channel=?, RemindTime=? WHERE User=?', [null, null, null, user.User]);
 
             const channel = channelFromMode(user);
             
-            const isDisabled = await commandDisabled('cookie', stream.username);
+            let isDisabled  = false;
+            if (stream !== null) {
+                isDisabled = await commandDisabled('cookie', stream.username);
+            }
             if (isDisabled) {
                 sendMessage(channel, user.User, `- This reminder is from a channel that has disabled cookie reminders[${user.Channel}]`);
-            } else if (stream.islive) {
+            } else if (stream?.islive) {
                 sendMessage(channel, user.User, `- This reminder is from a channel that is live[${user.Channel}]`);
             } else {
                 if (user.Mode === positive_bot.CONSTANTS.MODES.whereAte) {
@@ -243,12 +245,14 @@ setInterval(async function () {
 
         /** @type { SQL.Streamers[] } */
         const [stream] = await sql.Query('SELECT islive, username FROM Streamers WHERE username=?', [user.Channel]);
-        if (stream === null) return;
 
         await sql.Query('UPDATE Cdr SET Status=?, Channel=?, RemindTime=? WHERE User=?', [null, null, null, user.User]);
 
         const channel = channelFromMode(user);
-        const isDisabled = await commandDisabled('cookie', stream.username);
+        let isDisabled = false;
+        if (stream !== null) {
+            isDisabled = await commandDisabled('cookie', stream.username);
+        }
         if (isDisabled) {
             sendMessage(channel, user.User, `- This reminder is from a channel that has disabled cookie reminders[${user.Channel}]`);
         } else if (stream.islive) {

--- a/loops/loops.js
+++ b/loops/loops.js
@@ -287,10 +287,10 @@ setInterval(async function () {
     switch (user.Mode) {
         case positive_bot.CONSTANTS.MODES.whereAte:
         case positive_bot.CONSTANTS.MODES.ownChannel: {
-            return `#${user.User}`;
+            return `${user.User}`;
         }
         case positive_bot.CONSTANTS.MODES.botChannel: {
-            return '#botbear1110'; // TODO change this to a configurable channel ?
+            return 'botbear1110'; // TODO change this to a configurable channel ?
         }
     }
 };

--- a/reminders/cdr.js
+++ b/reminders/cdr.js
@@ -1,7 +1,7 @@
 const sql = require('../sql/index.js');
 const CONSTANTS = require('./constants');
 
-exports.validateIsPositiveBot = (input, user) => {
+exports.validateIsPositiveBot = (user, input) => {
     if (user['user-id'] !== CONSTANTS.POSITIVE_BOT) return false;
     if (!input.join(' ').includes('your cooldown has been reset!')) return false;
     return true;

--- a/reminders/cookie.js
+++ b/reminders/cookie.js
@@ -105,7 +105,7 @@ exports.allowedCookie = async (channel, input) => {
         UPDATE Cookies
         SET Status = ?,
             Channel = ?,
-            RemindTime = ?,
+            RemindTime = ?
         WHERE User = ?
     `, [response, channel, remindtime, realuser]);
 

--- a/sql/index.js
+++ b/sql/index.js
@@ -67,7 +67,7 @@ module.exports = {
 			})
 			.catch((err) => {
 				// TODO Melon: Should this throw or not.
-				console.error(`MySQL error: ${err}`);
+				console.error(new Error(`MySQL Error: ${err}`));
 				return null;
 			});
 	},

--- a/tools/messageHandler.js
+++ b/tools/messageHandler.js
@@ -29,6 +29,7 @@ exports.messageHandler = class Cooldown {
 		require('../bot.js').start;
 
 		if (process.env.TWITCH_USER === 'devbear1110' && this.channel !== 'hottestbear') {
+			console.log(`Channel: #${this.channel} - msg: ${this.message}`);
 			return;
 		}
 		if (this.channel === '#forsen') {


### PR DESCRIPTION
There was a bug with the cookie & cdr reminder loop, where if the user doesn't have the bot in their own channel, (Streamers) table. They would not get a notification.

Also, made it so if there is an error with MySQL, it should show a stacktrace.