### PR TITLE
fix: cookie reminder, ignore messages with rank

### DIFF
--- a/reminders/cookie.js
+++ b/reminders/cookie.js
@@ -16,7 +16,6 @@ const CONSTANTS = require('./constants.js');
 
 /**
  * @typedef { 'Confirmed' | 'Confirmed2' | 'CD' | '' } CookieStatus
- * 
  */
 
 /**
@@ -30,13 +29,16 @@ const CONSTANTS = require('./constants.js');
         return false;
     }
 
-    const joined = input.join(' ');
+    const joined = input.join(' ').replace(/user.username/g, '');
 
     if (input[0] !== '[Cookies]' || 
-    /* Ignore anything related to rank
-        This would be ?rank ?rankup ?prestige
-    */ 
-        joined.includes('rank')) {
+        joined.includes([
+                'ranked up' || // !rankup success 
+                'reset your rank' || // !prestige success
+                'rankup' || // !rankup fail
+                'ranked high enough' || // !prestige fail
+                'you are currently rank'] // rank
+                )) {
         return false;
     }
 

--- a/reminders/cookie.js
+++ b/reminders/cookie.js
@@ -30,8 +30,13 @@ const CONSTANTS = require('./constants.js');
         return false;
     }
 
+    const joined = input.join(' ');
+
     if (input[0] !== '[Cookies]' || 
-            input.join(' ').includes('rankup', 'you are currently rank')) {
+    /* Ignore anything related to rank
+        This would be ?rank ?rankup ?prestige
+    */ 
+        joined.includes('rank')) {
         return false;
     }
 

--- a/reminders/cookie.js
+++ b/reminders/cookie.js
@@ -37,7 +37,7 @@ const CONSTANTS = require('./constants.js');
                 'reset your rank' || // !prestige success
                 'rankup' || // !rankup fail
                 'ranked high enough' || // !prestige fail
-                'you are currently rank'] // rank
+                'you are currently rank'] // !rank
                 )) {
         return false;
     }


### PR DESCRIPTION
Botbear should ignore any PositiveBot messages based around `?rank`, `?rankup` and `?prestige`. 